### PR TITLE
feat(Game) update utils to class and track game scoring

### DIFF
--- a/twenty-fourty-eight/Actions/BoardActions.swift
+++ b/twenty-fourty-eight/Actions/BoardActions.swift
@@ -9,6 +9,7 @@ enum BoardAction: Equatable {
     case swipe(SwipeDirection)
     case addNewTile
     case checkGameOver
+    case tallyScore(Int)
 }
 
 enum SwipeDirection {

--- a/twenty-fourty-eight/Reducers/BoardReducer.swift
+++ b/twenty-fourty-eight/Reducers/BoardReducer.swift
@@ -28,11 +28,12 @@ let boardReducer = Reducer<BoardState, BoardAction, BoardEnvironment> { state, a
     switch action {
     case let .swipe(direction):
         let initialMatrix = state.matrix
-        state.matrix = BoardUtils.swipe(state.matrix, to: direction)
+        var boardUtils = BoardUtils(state.matrix)
+        state.matrix = boardUtils.swipe(direction)
         if state.matrix == initialMatrix {
             return .none
         }
-        return Just(.addNewTile).eraseToEffect()
+        return Just(.tallyScore(boardUtils.points)).eraseToEffect()
 
     case .addNewTile:
         if let emptyTileCoordinate = env.randomEmptyTile(state.matrix) {
@@ -41,6 +42,9 @@ let boardReducer = Reducer<BoardState, BoardAction, BoardEnvironment> { state, a
         }
 
         return Just(.checkGameOver).eraseToEffect()
+
+    case .tallyScore:
+        return Just(.addNewTile).eraseToEffect()
 
     case .checkGameOver:
         return .none

--- a/twenty-fourty-eight/Reducers/BoardReducerTests.swift
+++ b/twenty-fourty-eight/Reducers/BoardReducerTests.swift
@@ -34,6 +34,7 @@ class BoardFlowTests: XCTestCase {
                 [4, 16, 8, 128],
             ]
         }
+        store.receive(.tallyScore(4 + 8))
         store.receive(.addNewTile) {
             $0.newestTile = (1, 1)
         }
@@ -46,6 +47,7 @@ class BoardFlowTests: XCTestCase {
                 [4, 16, 16, 256],
             ]
         }
+        store.receive(.tallyScore(16 + 256))
         store.receive(.addNewTile)
         store.receive(.checkGameOver)
         store.send(.swipe(.left)) {
@@ -56,6 +58,7 @@ class BoardFlowTests: XCTestCase {
                 [4, 32, 256, 0],
             ]
         }
+        store.receive(.tallyScore(32))
         store.receive(.addNewTile)
         store.receive(.checkGameOver)
         store.send(.swipe(.up)) {
@@ -66,6 +69,18 @@ class BoardFlowTests: XCTestCase {
                 [0, 0, 0, 0],
             ]
         }
+        store.receive(.tallyScore(8))
+        store.receive(.addNewTile)
+        store.receive(.checkGameOver)
+        store.send(.swipe(.right)) {
+            $0.matrix = [
+                [0, 8, 32, 256],
+                [0, 0, 0, 0],
+                [0, 0, 0, 0],
+                [0, 0, 0, 0],
+            ]
+        }
+        store.receive(.tallyScore(0))
         store.receive(.addNewTile)
         store.receive(.checkGameOver)
     }
@@ -80,14 +95,11 @@ class BoardFlowTests: XCTestCase {
                 [4, 16, 8, 128],
             ]
         }
+        store.receive(.tallyScore(4 + 8))
         store.receive(.addNewTile) {
             $0.newestTile = store.environment.randomEmptyTile($0.matrix)
         }
         store.receive(.checkGameOver)
-        store.send(.swipe(.right))
-
-        // by sending the action again, we confirm there was no effect emitting from the previous action
-        // TODO: is there an actual way of asserting this?
         store.send(.swipe(.right))
     }
 
@@ -103,6 +115,7 @@ class BoardFlowTests: XCTestCase {
                 [4, 2, 4, 2],
             ]
         }
+        store.receive(.tallyScore(0))
         store.receive(.addNewTile) {
             $0.matrix = [
                 [2, 4, 2, 4],

--- a/twenty-fourty-eight/Reducers/GameReducer.swift
+++ b/twenty-fourty-eight/Reducers/GameReducer.swift
@@ -26,6 +26,9 @@ let gameReducer = Reducer<GameState, GameAction, GameEnvironment>.combine(
                 state.alert = state.gameOverAlert()
             }
             return .none
+        case let .board(.tallyScore(points)):
+            state.score += points
+            return .none
         case .board:
             return .none
         case .menuButtonTapped:

--- a/twenty-fourty-eight/Reducers/GameReducerTests.swift
+++ b/twenty-fourty-eight/Reducers/GameReducerTests.swift
@@ -60,4 +60,23 @@ class GameFlowTests: XCTestCase {
         }
         store.receive(.board(.checkGameOver))
     }
+
+    func testScoreFlow() {
+        let store = TestStore(initialState: GameState(board: BoardState(matrix: initialMatrix)), reducer: gameReducer, environment: .mock)
+        store.send(.board(.swipe(.right))) {
+            $0.board.matrix = [
+                [0, 0, 0, 4],
+                [0, 0, 8, 128],
+                [0, 0, 0, 0],
+                [4, 16, 8, 128],
+            ]
+        }
+        store.receive(.board(.tallyScore(4 + 8))) {
+            $0.score += 4 + 8
+        }
+        store.receive(.board(.addNewTile)) {
+            $0.board.newestTile = (1, 1)
+        }
+        store.receive(.board(.checkGameOver))
+    }
 }

--- a/twenty-fourty-eight/Utils/BoardUtils.swift
+++ b/twenty-fourty-eight/Utils/BoardUtils.swift
@@ -5,7 +5,14 @@
 //  Created by Phil Vargas on 7/13/22.
 //
 
-enum BoardUtils {
+class BoardUtils {
+    let matrix: BoardMatrix
+    var points = 0
+
+    init(_ matrix: BoardMatrix) {
+        self.matrix = matrix
+    }
+
     static func generateNewTileValue() -> Int {
         (Array(repeating: 2, count: 9) + [4]).randomElement()!
     }
@@ -14,7 +21,7 @@ enum BoardUtils {
         zeroCoordinates(matrix).randomElement()
     }
 
-    private static func zeroCoordinates(_ matrix: BoardMatrix) -> [TileCoordinate] {
+    internal static func zeroCoordinates(_ matrix: BoardMatrix) -> [TileCoordinate] {
         var coordinates: [TileCoordinate] = []
         for row in 0 ..< matrix.count {
             for col in 0 ..< matrix[row].count {
@@ -27,7 +34,7 @@ enum BoardUtils {
         return coordinates
     }
 
-    static func slide(_ row: BoardRow) -> BoardRow {
+    internal func slide(_ row: BoardRow) -> BoardRow {
         let nonzeroRow = row.filter { value in value > 0 }
         let zeroPad = Array(repeating: 0, count: 4 - nonzeroRow.count)
         return zeroPad + nonzeroRow
@@ -45,7 +52,7 @@ enum BoardUtils {
     //
     // We end the merge when the current index is the last element of
     // the row, it has nothing to merge with behind it.
-    static func merge(_ row: BoardRow, index: Int = 0) -> BoardRow {
+    internal func merge(_ row: BoardRow, index: Int = 0) -> BoardRow {
         let nextIndex = index + 1
         if nextIndex >= row.endIndex { return row }
 
@@ -55,12 +62,13 @@ enum BoardUtils {
         if first == second, first > 0 {
             newRow[index] = first + second
             newRow.remove(at: nextIndex)
+            points += first + second
         }
         return merge(newRow.reversed(), index: nextIndex)
     }
 
     // Rotate matrix clockwise by 90 degrees
-    static func rotateClockwise(_ matrix: BoardMatrix) -> BoardMatrix {
+    internal func rotateClockwise(_ matrix: BoardMatrix) -> BoardMatrix {
         let len = matrix.count
         var newBoard = matrix
 
@@ -81,31 +89,34 @@ enum BoardUtils {
     }
 
     // Rotate matrix clockwise by 180 degrees
-    static func flip(_ matrix: BoardMatrix) -> BoardMatrix {
+    internal func flip(_ matrix: BoardMatrix) -> BoardMatrix {
         rotateClockwise(rotateClockwise(matrix))
     }
 
     // Rotate matrix counter clockwise 90 degrees, or clockwise by 270 degrees
-    static func rotateCounterClockwise(_ matrix: BoardMatrix) -> BoardMatrix {
+    internal func rotateCounterClockwise(_ matrix: BoardMatrix) -> BoardMatrix {
         rotateClockwise(rotateClockwise(rotateClockwise(matrix)))
     }
 
-    private static func swipe(_ matrix: BoardMatrix) -> BoardMatrix {
+    internal func swipe(_ matrix: BoardMatrix) -> BoardMatrix {
         matrix.map(slide)
             .map { row in merge(row) }
             .map(slide)
     }
 
-    static func swipe(_ matrix: BoardMatrix, to direction: SwipeDirection) -> BoardMatrix {
+    func swipe(_ direction: SwipeDirection) -> BoardMatrix {
+        let matrix: BoardMatrix
         switch direction {
         case .right:
-            return swipe(matrix)
+            matrix = swipe(self.matrix)
         case .up:
-            return rotateCounterClockwise(swipe(rotateClockwise(matrix)))
+            matrix = rotateCounterClockwise(swipe(rotateClockwise(self.matrix)))
         case .left:
-            return flip(swipe(flip(matrix)))
+            matrix = flip(swipe(flip(self.matrix)))
         case .down:
-            return rotateClockwise(swipe(rotateCounterClockwise(matrix)))
+            matrix = rotateClockwise(swipe(rotateCounterClockwise(self.matrix)))
         }
+
+        return matrix
     }
 }

--- a/twenty-fourty-eight/Utils/BoardUtilsTests.swift
+++ b/twenty-fourty-eight/Utils/BoardUtilsTests.swift
@@ -9,64 +9,71 @@
 import XCTest
 
 class BoardUtilsTests: XCTestCase {
+    let boardUtils = BoardUtils([
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+        [13, 14, 15, 16],
+    ])
+
     func testSlide() {
         let initialRow = [2, 0, 4, 0]
         let expectedRow = [0, 0, 2, 4]
-        XCTAssertEqual(BoardUtils.slide(initialRow), expectedRow)
+        XCTAssertEqual(boardUtils.slide(initialRow), expectedRow)
     }
 
     func testSlideReducedRow() {
         let initialRow = [2, 4, 0]
         let expectedRow = [0, 0, 2, 4]
-        XCTAssertEqual(BoardUtils.slide(initialRow), expectedRow)
+        XCTAssertEqual(boardUtils.slide(initialRow), expectedRow)
     }
 
     func testMergeNone() {
         let initialRow = [2, 4, 8, 16]
         let expectedRow = [2, 4, 8, 16]
-        XCTAssertEqual(BoardUtils.merge(initialRow), expectedRow)
+        XCTAssertEqual(boardUtils.merge(initialRow), expectedRow)
     }
 
     func testMergeNoneWithZeros() {
         let initialRow = [0, 2, 4, 2]
         let expectedRow = [0, 2, 4, 2]
-        XCTAssertEqual(BoardUtils.merge(initialRow), expectedRow)
+        XCTAssertEqual(boardUtils.merge(initialRow), expectedRow)
     }
 
     func testMergePairs() {
         let initialRow = [0, 0, 2, 2]
         let expectedRow = [0, 0, 4]
-        XCTAssertEqual(BoardUtils.merge(initialRow), expectedRow)
+        XCTAssertEqual(boardUtils.merge(initialRow), expectedRow)
     }
 
     func testMergePairsMiddle() {
         let initialRow = [0, 2, 2, 16]
         let expectedRow = [0, 4, 16]
-        XCTAssertEqual(BoardUtils.merge(initialRow), expectedRow)
+        XCTAssertEqual(boardUtils.merge(initialRow), expectedRow)
     }
 
     func testMergePairsEnd() {
         let initialRow = [2, 2, 4, 16]
         let expectedRow = [4, 4, 16]
-        XCTAssertEqual(BoardUtils.merge(initialRow), expectedRow)
+        XCTAssertEqual(boardUtils.merge(initialRow), expectedRow)
     }
 
     func testMergeTriplets() {
         let initialRow = [0, 4, 2, 2]
         let expectedRow = [0, 4, 4]
-        XCTAssertEqual(BoardUtils.merge(initialRow), expectedRow)
+        XCTAssertEqual(boardUtils.merge(initialRow), expectedRow)
     }
 
     func testMergeTripletsEnd() {
         let initialRow = [4, 2, 2, 16]
         let expectedRow = [4, 4, 16]
-        XCTAssertEqual(BoardUtils.merge(initialRow), expectedRow)
+        XCTAssertEqual(boardUtils.merge(initialRow), expectedRow)
     }
 
     func testMergeQuads() {
         let initialRow = [2, 2, 2, 2]
         let expectedRow = [4, 4]
-        XCTAssertEqual(BoardUtils.merge(initialRow), expectedRow)
+        XCTAssertEqual(boardUtils.merge(initialRow), expectedRow)
     }
 
     func testRotate() {
@@ -82,7 +89,7 @@ class BoardUtilsTests: XCTestCase {
             [15, 11, 7, 3],
             [16, 12, 8, 4],
         ]
-        XCTAssertEqual(BoardUtils.rotateClockwise(initialBoard), expectedBoard)
+        XCTAssertEqual(boardUtils.rotateClockwise(initialBoard), expectedBoard)
     }
 
     func testRotate180() {
@@ -98,7 +105,8 @@ class BoardUtilsTests: XCTestCase {
             [8, 7, 6, 5],
             [4, 3, 2, 1],
         ]
-        XCTAssertEqual(BoardUtils.rotateClockwise(BoardUtils.rotateClockwise(initialBoard)), expectedBoard)
+
+        XCTAssertEqual(boardUtils.rotateClockwise(boardUtils.rotateClockwise(initialBoard)), expectedBoard)
     }
 
     func testRotate270() {
@@ -114,10 +122,10 @@ class BoardUtilsTests: XCTestCase {
             [2, 6, 10, 14],
             [1, 5, 9, 13],
         ]
-        XCTAssertEqual(BoardUtils.rotateClockwise(BoardUtils.rotateClockwise(BoardUtils.rotateClockwise(initialBoard))), expectedBoard)
+        XCTAssertEqual(boardUtils.rotateClockwise(boardUtils.rotateClockwise(boardUtils.rotateClockwise(initialBoard))), expectedBoard)
     }
 
-    func testSwipe() {
+    func testSwipeRight() {
         let initialBoard = [
             [0, 0, 2, 2],
             [0, 4, 4, 8],
@@ -130,6 +138,19 @@ class BoardUtilsTests: XCTestCase {
             [0, 0, 0, 0],
             [16, 32, 64, 128],
         ]
-        XCTAssertEqual(BoardUtils.swipe(initialBoard, to: .right), expectedBoard)
+        XCTAssertEqual(BoardUtils(initialBoard).swipe(.right), expectedBoard)
+    }
+
+    func testScore() {
+        let initialBoard = [
+            [0, 0, 2, 2],
+            [0, 4, 4, 8],
+            [0, 0, 0, 0],
+            [16, 32, 64, 128],
+        ]
+
+        let boardUtils = BoardUtils(initialBoard)
+        _ = boardUtils.swipe(.right)
+        XCTAssertEqual(boardUtils.points, 12)
     }
 }

--- a/twenty-fourty-eight/Utils/GameUtils.swift
+++ b/twenty-fourty-eight/Utils/GameUtils.swift
@@ -8,9 +8,9 @@
 enum GameUtils {
     static func isGameOver(_ matrix: BoardMatrix) -> Bool {
         return BoardUtils.randomEmptyTile(matrix) == nil &&
-            BoardUtils.swipe(matrix, to: .right) == matrix &&
-            BoardUtils.swipe(matrix, to: .left) == matrix &&
-            BoardUtils.swipe(matrix, to: .up) == matrix &&
-            BoardUtils.swipe(matrix, to: .down) == matrix
+            BoardUtils(matrix).swipe(.right) == matrix &&
+            BoardUtils(matrix).swipe(.left) == matrix &&
+            BoardUtils(matrix).swipe(.up) == matrix &&
+            BoardUtils(matrix).swipe(.down) == matrix
     }
 }

--- a/twenty-fourty-eight/Views/GameView.swift
+++ b/twenty-fourty-eight/Views/GameView.swift
@@ -37,14 +37,19 @@ struct GameView: View {
                             .font(.system(size: 16, weight: .bold, design: .rounded))
                             .padding(.top, 4)
 
-                        Text("9001")
+                        Text("\(viewStore.score)")
                             .font(.system(size: 24, weight: .bold, design: .rounded))
+                            .scaledToFit()
+                            .minimumScaleFactor(0.5)
                             .padding(.horizontal, 30)
                             .padding(.bottom, 4)
                     }
+                    .frame(width: 150, height: 55, alignment: .center)
+                    .fixedSize()
                     .background(Color.buttonBackground(.primary))
                     .foregroundColor(.textColor(.secondary))
                     .cornerRadius(4)
+
                     Spacer()
                 }
                 HStack {


### PR DESCRIPTION
## Changes
- implement score counter
- convert board utils to a class so we can track a score during the merge row process
- game flow now swipes -> trackScore -> addNewTile -> checkGameOver